### PR TITLE
fix tests.xml for different Qt versions

### DIFF
--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -16,7 +16,7 @@ target.path = /usr/bin
 
 tests_xml.target = tests.xml
 tests_xml.depends = $$PWD/tests.xml.in
-tests_xml.commands = sed -e "s:@PACKAGENAME@:$${PACKAGENAME}:g" $< > $@
+tests_xml.commands = sed -e "s:@PACKAGENAME@:$${PACKAGENAME}:g" -e \'s%@PATH@%$${target.path}%\' $<  > $@
 tests_xml.CONFIG += no_check_exist
 
 QMAKE_EXTRA_TARGETS = tests_xml

--- a/tests/tests.xml.in
+++ b/tests/tests.xml.in
@@ -3,11 +3,13 @@
     <set name="@PACKAGENAME@-simple_tests" description="basic iodata functionality" feature="System Control" requirement="MaSSW-815, MaSSW-1167">
       <environments><scratchbox>false</scratchbox><hardware>true</hardware></environments>
       <case name="trivial" description="parse a trivial structure from a string" subfeature="TimeAlarm">
-        <step>iodata-test trivial</step>
+        <step>@PATH@/@PACKAGENAME@-test trivial</step>
       </case>
+<!--  NOT implemented yet
       <case name="storage" description="load, save, use default values" subfeature="TimeAlarm">
         <step>iodata-test storage</step>
       </case>
+-->
     </set>
   </suite>
 </testdefinition>


### PR DESCRIPTION
depending on the qt version the binary has different name, the storage test is not yet implemented in C code. So it adds no value to run that test.
